### PR TITLE
configured SvgReactPanZoomLoader to take the width and height of its …

### DIFF
--- a/src/ReactSvgPanZoomLoader.js
+++ b/src/ReactSvgPanZoomLoader.js
@@ -10,7 +10,7 @@ import { SvgLoader } from 'react-svgmt'
  */
 const ReactSvgPanZoomLoader = (props) => {
     return (
-        <div style={{width:'100%', height:'100%'}}>
+        <div className={props.className}>
             {props.render(
                 <SvgLoader path={props.src} svgXML={props.svgXML}>
                     {props.proxy}

--- a/src/ReactSvgPanZoomLoader.js
+++ b/src/ReactSvgPanZoomLoader.js
@@ -10,7 +10,7 @@ import { SvgLoader } from 'react-svgmt'
  */
 const ReactSvgPanZoomLoader = (props) => {
     return (
-        <div>
+        <div style={{width:'100%', height:'100%'}}>
             {props.render(
                 <SvgLoader path={props.src} svgXML={props.svgXML}>
                     {props.proxy}


### PR DESCRIPTION
…parent container


Since the ReactSvgPanZoomLoader creates a <div> element without any styling for its width and height it was not able to take a dynamic dimension specified by a percentage of its parent container. Before this change the width and height of the <div> expanded to fit the dimension of by the child component that ReactSvgPanZoomLoader loads in the render prop. 

This is not a necessary change for the functionality of the component but it was a change I had to do for a project I was working on. I figured I would create a pull request in case anyone else thinks it's helpful. 
